### PR TITLE
chore: fix conflicting workspace package names

### DIFF
--- a/solutions/week_1/jackddouglas/Cargo.toml
+++ b/solutions/week_1/jackddouglas/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jackddouglas"
+name = "week_1"
 version = "0.1.0"
 edition = "2021"
 

--- a/solutions/week_2/jackddouglas/Cargo.toml
+++ b/solutions/week_2/jackddouglas/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jackddouglas"
+name = "week_2"
 version = "0.1.0"
 edition = "2021"
 

--- a/solutions/week_3/jackddouglas/Cargo.toml
+++ b/solutions/week_3/jackddouglas/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jackddouglas"
+name = "week_3"
 version = "0.1.0"
 edition = "2021"
 

--- a/solutions/week_4/jackddouglas/Cargo.toml
+++ b/solutions/week_4/jackddouglas/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jackddouglas"
+name = "week_4"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Renames conflicting package names

This solves this bug:

```sh
cargo run
error: two packages named `jackddouglas` in this workspace:
- /Users/arthurgousset/Documents/tonk/schola/solutions/week_3/jackddouglas/Cargo.toml
- /Users/arthurgousset/Documents/tonk/schola/solutions/week_4/jackddouglas/Cargo.toml
```